### PR TITLE
Fix an AIOOB when an enchantment > lv3 is found

### DIFF
--- a/src/main/java/arlyon/felling/FellingAlgorithm.java
+++ b/src/main/java/arlyon/felling/FellingAlgorithm.java
@@ -162,7 +162,7 @@ public class FellingAlgorithm {
      * @return The list of paths matching the felling enchantment version.
      */
     private static EnumFacing[][] getPaths(ItemStack item) {
-        return fellingPaths[EnchantmentHelper.getEnchantmentLevel(Felling.felling, item) - 1];
+        return fellingPaths[Math.min(EnchantmentHelper.getEnchantmentLevel(Felling.felling, item), 3) - 1];
     }
 
     /**


### PR DESCRIPTION
Currently if an axe with Felling IV (or higher) is encountered, the game crashes with an AIOOB.  Unsure if this is also the case with Veining, I'll probably go test that soon.